### PR TITLE
parameterize `NUFFTPlan` array types

### DIFF
--- a/ext/VLBISkyModelsReactantExt/nufft/plan.jl
+++ b/ext/VLBISkyModelsReactantExt/nufft/plan.jl
@@ -15,7 +15,7 @@ Static plan parameters. `T` is the real eltype, `D` is the dimensionality,
 
 Construct via [`plan_nufft`](@ref).
 """
-struct NUFFTPlan{T <: Real, D, K}
+struct NUFFTPlan{T <: Real, D, K, CoefsType<:AbstractMatrix, PhiHatType<:AbstractVector}
     nmodes::NTuple{D, Int}
     ngrid::NTuple{D, Int}
     iflag::Int                        # +1 or -1
@@ -26,9 +26,11 @@ struct NUFFTPlan{T <: Real, D, K}
     bin_dims::NTuple{D, Int}
     nbins::NTuple{D, Int}
     chunk_size::Int
-    horner_coefs::Matrix{T}           # (w, deg+1)
-    phi_hat::NTuple{D, Vector{T}}      # length nmodes[d] each
+    horner_coefs::CoefsType           # (w, deg+1)
+    phi_hat::NTuple{D, PhiHatType}      # length nmodes[d] each
 end
+
+NUFFTPlan{T,D,K}(args...) where {T,D,K} = NUFFTPlan{T,D,K,Matrix{T},Vector{T}}(args...)
 
 nufft_type(::NUFFTPlan{<:Any, <:Any, K}) where {K} = K
 Base.eltype(::NUFFTPlan{T}) where {T} = T


### PR DESCRIPTION
this fixes the conversion to Reactant of `NUFFTPlan` and the serialization of the `horner_coefs` and `phi_hat` arrays when compiling with Reactant

@ptiede plus this change makes the analytic adjoint of the NUFFT benchmark like x100,000 faster (from 39s to 0.3 ms) sth weird was happening there)